### PR TITLE
provide graceful shutdown handling process

### DIFF
--- a/src/config/db/index.js
+++ b/src/config/db/index.js
@@ -4,7 +4,7 @@ import logger from "../logger/index.js"
 
 const { MONGODB_URI } = Config
 
-const connectDB = async () => {
+export const connectDB = async () => {
   try {
     const connectionInstance = await mongoose.connect(MONGODB_URI)
     logger.info(
@@ -16,4 +16,11 @@ const connectDB = async () => {
   }
 }
 
-export default connectDB
+export const releaseConnection = async () => {
+  try {
+    await mongoose.connection.close();
+    logger.info('☘️  Release MongoDB Connection Successfully!')
+  } catch (error) {
+    logger.error("Release MongoDB connection error: ", error.message)
+  }
+}


### PR DESCRIPTION
#17 done
To test the safely closed database & server, you can use the setTimout function in the endpoint. Try to set a 5-10 seconds wait time, then terminate the running server forcefully in your terminal.
The result will wait for the timeout and then successfully finish query execution. Then the console will exit the running server.

@Zack-Dx 